### PR TITLE
Fixes to bypass generated spin-deps code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-sdk",
+ "wit-bindgen 0.43.0",
 ]
 
 [[package]]

--- a/api-gateway/Cargo.toml
+++ b/api-gateway/Cargo.toml
@@ -12,3 +12,4 @@ anyhow = { workspace = true }
 spin-sdk = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+wit-bindgen = "0.43.0"

--- a/api-gateway/spin.toml
+++ b/api-gateway/spin.toml
@@ -11,7 +11,7 @@ route = "/..."
 component = "api-gateway"
 
 [component.api-gateway]
-source = "target/wasm32-wasip1/release/api_gateway.wasm"
+source = "../target/wasm32-wasip1/debug/api_gateway.wasm"
 allowed_outbound_hosts = []
 [component.api-gateway.build]
 command = "cargo build --target wasm32-wasip1 --release"

--- a/api-gateway/src/deps/component_api1.rs
+++ b/api-gateway/src/deps/component_api1.rs
@@ -1,4 +1,4 @@
-::spin_sdk::wit_bindgen::generate!({
+wit_bindgen::generate!({
     inline: r#"
     package imported:component-api1;
     world imports {
@@ -9,4 +9,5 @@
         "component:api1/data-handler": generate,
     },
     path: ".wit/components/deps/api1/component-api1.wit",
+    additional_derives: [serde::Deserialize],
 });

--- a/api-gateway/src/lib.rs
+++ b/api-gateway/src/lib.rs
@@ -1,6 +1,6 @@
 mod deps;
 
-use bindings::deps::component::api1::data_handler::{handle_data, MyObject};
+use deps::component_api1::component::api1::data_handler::{handle_data, MyObject};
 use spin_sdk::http::{IntoResponse, Request, Response};
 use spin_sdk::http_component;
 use serde_json::from_slice;


### PR DESCRIPTION
Unfortunately the rust code generation of the spin-deps plugin is [broken](https://github.com/spinframework/spin-deps-plugin/issues/26). While that is investigated, this PR should unblock you. Let me know if you have any questions!